### PR TITLE
Add base64 annotation support for validations

### DIFF
--- a/spring-commons-rest-validation/README.md
+++ b/spring-commons-rest-validation/README.md
@@ -49,6 +49,8 @@ Functionality of this package is contained in Java package `com.github.damianwaj
 
 **@Max** – validates that the annotated property has a value no larger than the value attribute
 
+**@Base64** – validates that the annotated property is a valid base64 encoded string
+
 **@Email** – validates that the annotated property is a valid email address
 
 **@Pattern** – validate that a string matches with regex parameter.

--- a/spring-commons-rest-validation/pom.xml
+++ b/spring-commons-rest-validation/pom.xml
@@ -10,4 +10,11 @@
 		<artifactId>spring-commons-parent</artifactId>
 		<version>${revision}</version>
 	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.2</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/spring-commons-rest-validation/src/main/java/com/github/damianwajser/validator/annotation/strings/Base64.java
+++ b/spring-commons-rest-validation/src/main/java/com/github/damianwajser/validator/annotation/strings/Base64.java
@@ -1,0 +1,41 @@
+package com.github.damianwajser.validator.annotation.strings;
+
+import com.github.damianwajser.validator.constraint.strings.Base64Constraint;
+import org.springframework.http.HttpMethod;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = {Base64Constraint.class})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Repeatable(Base64.List.class)
+public @interface Base64 {
+
+    HttpMethod[] excludes() default {};
+
+    String message();
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String businessCode();
+
+    boolean isNulleable() default false;
+
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+        Base64[] value();
+    }
+}

--- a/spring-commons-rest-validation/src/main/java/com/github/damianwajser/validator/constraint/strings/Base64Constraint.java
+++ b/spring-commons-rest-validation/src/main/java/com/github/damianwajser/validator/constraint/strings/Base64Constraint.java
@@ -1,0 +1,28 @@
+package com.github.damianwajser.validator.constraint.strings;
+
+import com.github.damianwajser.validator.annotation.strings.Base64;
+import com.github.damianwajser.validator.constraint.AbstractConstraint;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import static org.apache.tomcat.util.codec.binary.Base64.isBase64;
+
+public class Base64Constraint extends AbstractConstraint implements ConstraintValidator<Base64, Object> {
+
+    @Override
+    public void initialize(Base64 field) {
+        super.excludes = field.excludes();
+        super.isNulleable = field.isNulleable();
+    }
+
+    /**
+     * This method returns true if any character is not a valid character in the Base64 alphabet.
+     * More information of used method could be found here:
+     * https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/binary/Base64.html#isBase64-java.lang.String-
+     */
+    @Override
+    protected boolean hasError(Object field, ConstraintValidatorContext cxt) {
+        return !isBase64(field.toString());
+    }
+}

--- a/spring-commons-rest-validation/src/test/java/com/github/damianwajser/model/strings/Base64StringObject.java
+++ b/spring-commons-rest-validation/src/test/java/com/github/damianwajser/model/strings/Base64StringObject.java
@@ -1,0 +1,25 @@
+package com.github.damianwajser.model.strings;
+
+import com.github.damianwajser.validator.annotation.strings.Base64;
+
+public class Base64StringObject {
+
+    @Base64(message = "error", businessCode = "a-400")
+    private String value;
+
+    public Base64StringObject() {
+    }
+
+    public Base64StringObject(String value) {
+        super();
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/spring-commons-rest-validation/src/test/java/com/github/damianwajser/tests/strings/Base64ValidationTest.java
+++ b/spring-commons-rest-validation/src/test/java/com/github/damianwajser/tests/strings/Base64ValidationTest.java
@@ -1,0 +1,24 @@
+package com.github.damianwajser.tests.strings;
+
+import com.github.damianwajser.model.strings.Base64StringObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static com.github.damianwajser.TestUtils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class Base64ValidationTest {
+
+    @Test
+    public void base64_string() {
+        assertThat(validationFor(new Base64StringObject(), onField("value")), fails());
+        assertThat(validationFor(new Base64StringObject("c3ByaW5nLWNvbW1vbnM="), onField("value")), succedes());
+        //isBase64 treats whitespace as valid
+        assertThat(validationFor(new Base64StringObject("a b c d"), onField("value")), succedes());
+        assertThat(validationFor(new Base64StringObject("c3ByaW5nLWNvbW1vbn..."), onField("value")), fails());
+        assertThat(validationFor(new Base64StringObject("abcd**"), onField("value")), fails());
+    }
+
+}


### PR DESCRIPTION
This PR adds support to base64 annotation for validations using this library:
https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/binary/Base64.html#isBase64-java.lang.String-

But in this case, an empty string is not accepted.